### PR TITLE
Improving the readability through minor changes to structure

### DIFF
--- a/NoComponentDrag.py
+++ b/NoComponentDrag.py
@@ -36,10 +36,12 @@ from .thomasa88lib import utils, events, manifest, error
 # To RE-import pre-referanced modules above the direct names can be used
 # VSCode intillesense does not like it if you do it with the directory (Gives not referenced error but still functions properly)
 import importlib
-importlib.reload(utils)
-importlib.reload(events)
-importlib.reload(manifest)
-importlib.reload(error)
+# Allows for re-import of multiple modules
+def ReImport_List(*args):
+	for module in args:
+		importlib.reload(module)
+ReImport_List(utils, events, manifest, error)
+
 
 NAME = 'NoComponentDrag'
 FILE_DIR = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
You could implement the function into your base utill or something to reduce the ugly multi-line reimport being done. I may have not have considered you would need to reimport the module containing the reimport function but even then, you can reduce every multi line import to two lines of 1 reimporting the other modules, and 2: reimporting explicitly the module containing the reimport so x amount of lines becomes 2 lines unless you wish to indent the list of modules being requested to re-import as such:
From:

 importlib.reload(utils)
 importlib.reload(events)
 importlib.reload(manifest)
 importlib.reload(error)

To:

ReImport_List(utils, events, manifest, error, ...)
importlib.reload(ReImport_List_Base_Module_Thing)